### PR TITLE
Fix conn/idle-timeout typo

### DIFF
--- a/src/duct/component/hikaricp.clj
+++ b/src/duct/component/hikaricp.clj
@@ -11,7 +11,7 @@
     (when password             (.setPassword cfg password))
     (when (some? auto-commit?) (.setAutoCommit cfg auto-commit?))
     (when conn-timeout         (.setConnectionTimeout cfg conn-timeout))
-    (when idle-timeout         (.setIdleTimeout cfg conn-timeout))
+    (when idle-timeout         (.setIdleTimeout cfg idle-timeout))
     (when max-lifetime         (.setMaxLifetime cfg max-lifetime))
     (when max-pool-size        (.setMaximumPoolSize cfg max-pool-size))
     (when min-idle             (.setMinimumIdle cfg min-idle))


### PR DESCRIPTION
…meout

I discovered this by setting idle-timeout without conn-timeout.